### PR TITLE
Example Scripts

### DIFF
--- a/scripts/test_6S.py
+++ b/scripts/test_6S.py
@@ -1,0 +1,47 @@
+import logging
+import numpy as np
+import os
+
+logging.basicConfig(level=logging.DEBUG)
+
+from isofit.configs import configs
+from isofit.radiative_transfer.six_s import SixSRT
+
+
+example = 'examples/20151026_SantaMonica'
+
+# Initialize the config
+cf = f"{example}/configs/prm20151026t173213_D9W_6s.json"
+fc = full_config = configs.create_new_config(cf)
+ec = engine_config = fc.forward_model.radiative_transfer.radiative_transfer_engines[0]
+lg = lut_grid = fc.forward_model.radiative_transfer.lut_grid
+
+# Update config for this test
+ec.engine_base_dir = os.environ['SIXS_DIR']
+ec.statevector_names = []
+
+#% Remove the LUT file, comment this if testing pre-existing lut
+import os
+if os.path.exists(ec.lut_path):
+    os.remove(ec.lut_path)
+
+# override size instead of using a wavelength_file (this is how sRTMnet uses 6S)
+N = 831
+
+#%%
+rte = SixSRT(
+    engine_config          = ec,
+    interpolator_style     = fc.forward_model.radiative_transfer.interpolator_style,
+    overwrite_interpolator = fc.forward_model.radiative_transfer.overwrite_interpolator,
+    wavelength_file        = f'{example}/data/20140221_PRISM_wavelengths_truncated_clip.txt',
+    lut_grid               = lut_grid,
+    lut_path               = ec.lut_path,
+    # Override
+    # wl                     = np.linspace(350, 2500, N),
+    # fwhm                   = np.full(N, 2)
+)
+
+#%%
+# Load the LUT and look around
+rte.lut.load()
+rte.lut.isel(point=6)

--- a/scripts/test_modtran.py
+++ b/scripts/test_modtran.py
@@ -1,0 +1,42 @@
+import logging
+import os
+import numpy as np
+
+logging.basicConfig(level=logging.DEBUG)
+
+from isofit.configs import configs
+from isofit.radiative_transfer.modtran import ModtranRT
+
+
+example = 'examples/20171108_Pasadena'
+
+cf = f"{example}/configs/ang20171108t184227_beckmanlawn.json"
+fc = full_config = configs.create_new_config(cf)
+ec = engine_config = fc.forward_model.radiative_transfer.radiative_transfer_engines[0]
+lg = lut_grid = fc.forward_model.radiative_transfer.lut_grid
+
+# Update config for this test
+...
+
+#% Remove the LUT file, comment this if testing pre-existing lut
+import os
+if os.path.exists(ec.lut_path):
+    os.remove(ec.lut_path)
+
+# Disable Modtran's makeSim for local testing
+ModtranRT.makeSim = lambda *_: ...
+
+# Build the RTE
+rte = ModtranRT(
+    engine_config          = engine_config,
+    lut_grid               = lut_grid,
+    lut_path               = engine_config.lut_path,
+    wavelength_file        = fc.forward_model.instrument.wavelength_file,
+    interpolator_style     = fc.forward_model.radiative_transfer.interpolator_style,
+    overwrite_interpolator = fc.forward_model.radiative_transfer.overwrite_interpolator,
+    cache_size             = fc.forward_model.radiative_transfer.cache_size
+)
+
+#%%
+
+rte.lut.load()

--- a/scripts/test_sRTMnet.py
+++ b/scripts/test_sRTMnet.py
@@ -1,0 +1,50 @@
+import os
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+from isofit.configs                    import configs
+from isofit.radiative_transfer.sRTMnet import SimulatedModtranRT
+
+
+example = 'examples/20171108_Pasadena'
+
+cf = f"{example}/configs/ang20171108t184227_beckmanlawn.json"
+fc = full_config = configs.create_new_config(cf)
+ec = engine_config = fc.forward_model.radiative_transfer.radiative_transfer_engines[0]
+lg = lut_grid = fc.forward_model.radiative_transfer.lut_grid
+
+#% Update config params for this test
+ec.wavelength_range  = None
+ec.irradiance_file   = f"{example}/../20151026_SantaMonica/data/prism_optimized_irr.dat"
+ec.engine_base_dir   = os.environ['SIXS_DIR']
+
+# Path to emulator
+ec.emulator_aux_file = os.environ['EMULATOR_PATH'] + '/sRTMnet_v100_aux.npz'
+ec.emulator_file     = os.environ['EMULATOR_PATH'] + '/sRTMnet_v100'
+
+#% Remove LUT files
+files = [
+    ec.lut_path,
+    ec.lut_path + '.6S',
+    ec.sim_path + '/sRTMnet.predicts.nc'
+]
+
+for file in files:
+    if os.path.exists(file):
+        print(f'Removing {file}')
+        os.remove(file)
+
+#%%
+rte = SimulatedModtranRT(
+    engine_config          = ec,
+    interpolator_style     = fc.forward_model.radiative_transfer.interpolator_style,
+    overwrite_interpolator = fc.forward_model.radiative_transfer.overwrite_interpolator,
+    wavelength_file        = fc.forward_model.instrument.wavelength_file,
+    lut_grid               = lut_grid,
+    lut_path               = ec.lut_path
+)
+
+#%%
+
+rte.lut.load()


### PR DESCRIPTION
Adds a few scripts that I was using for testing RTEs back during the 3.0 refactor that may be good to show how to pull an engine into a test environment and execute directly. 