### PR TITLE
Bad path fix

### DIFF
--- a/20171108_Pasadena/templates/topoflux/ang20171108t184227_beckmanlawn-multimodtran-topoflux.json
+++ b/20171108_Pasadena/templates/topoflux/ang20171108t184227_beckmanlawn-multimodtran-topoflux.json
@@ -17,7 +17,7 @@
 
     "instrument": {
       "wavelength_file": "{examples}/20171108_Pasadena/remote/20170320_ang20170228_wavelength_fit.txt",
-      "parametric_noise_file": ".{data}/avirisng_noise.txt",
+      "parametric_noise_file": "{data}/avirisng_noise.txt",
       "integrations":294,
       "unknowns": {
         "channelized_radiometric_uncertainty_file":


### PR DESCRIPTION
Removes a `.` that's causing the generated config to produce a bad path.