### PR TITLE
Expanding ImageCube Examples

### DIFF
--- a/image_cube/medium/templates/analytical.args.json
+++ b/image_cube/medium/templates/analytical.args.json
@@ -1,0 +1,14 @@
+[
+  "{imagecube}/medium/ang20170323t202244_rdn_7k-8k",
+  "{imagecube}/medium/ang20170323t202244_obs_7k-8k",
+  "{imagecube}/medium/ang20170323t202244_loc_7k-8k",
+  "{examples}/image_cube/medium",
+  "ang",
+  "--surface_path {examples}/image_cube/medium/configs/surface.json",
+  "--emulator_base {srtmnet}/sRTMnet_v120.h5",
+  "--n_cores {cores}",
+  "--presolve",
+  "--segmentation_size 400",
+  "--pressure_elevation",
+  "--analytical_line"
+]

--- a/image_cube/medium/templates/default.args.json
+++ b/image_cube/medium/templates/default.args.json
@@ -1,0 +1,13 @@
+[
+  "{imagecube}/medium/ang20170323t202244_rdn_7k-8k",
+  "{imagecube}/medium/ang20170323t202244_obs_7k-8k",
+  "{imagecube}/medium/ang20170323t202244_loc_7k-8k",
+  "{examples}/image_cube/medium",
+  "ang",
+  "--surface_path {examples}/image_cube/medium/configs/surface.json",
+  "--emulator_base {srtmnet}/sRTMnet_v120.h5",
+  "--n_cores {cores}",
+  "--presolve",
+  "--segmentation_size 400",
+  "--pressure_elevation"
+]

--- a/image_cube/medium/templates/empirical.args.json
+++ b/image_cube/medium/templates/empirical.args.json
@@ -5,8 +5,10 @@
   "{examples}/image_cube/medium",
   "ang",
   "--surface_path {examples}/image_cube/medium/configs/surface.json",
+  "--emulator_base {srtmnet}/sRTMnet_v120.h5",
   "--n_cores {cores}",
   "--presolve",
   "--segmentation_size 400",
-  "--pressure_elevation"
+  "--pressure_elevation",
+  "--empirical_line"
 ]

--- a/image_cube/small/templates/analytical.args.json
+++ b/image_cube/small/templates/analytical.args.json
@@ -5,8 +5,10 @@
   "{examples}/image_cube/small",
   "ang",
   "--surface_path {examples}/image_cube/small/configs/surface.json",
+  "--emulator_base {srtmnet}/sRTMnet_v120.h5",
   "--n_cores {cores}",
   "--presolve",
   "--segmentation_size 400",
-  "--pressure_elevation"
+  "--pressure_elevation",
+  "--analytical_line"
 ]

--- a/image_cube/small/templates/default.args.json
+++ b/image_cube/small/templates/default.args.json
@@ -1,0 +1,13 @@
+[
+  "{imagecube}/small/ang20170323t202244_rdn_7000-7010",
+  "{imagecube}/small/ang20170323t202244_obs_7000-7010",
+  "{imagecube}/small/ang20170323t202244_loc_7000-7010",
+  "{examples}/image_cube/small",
+  "ang",
+  "--surface_path {examples}/image_cube/small/configs/surface.json",
+  "--emulator_base {srtmnet}/sRTMnet_v120.h5",
+  "--n_cores {cores}",
+  "--presolve",
+  "--segmentation_size 400",
+  "--pressure_elevation"
+]

--- a/image_cube/small/templates/empirical.args.json
+++ b/image_cube/small/templates/empirical.args.json
@@ -1,0 +1,14 @@
+[
+  "{imagecube}/small/ang20170323t202244_rdn_7000-7010",
+  "{imagecube}/small/ang20170323t202244_obs_7000-7010",
+  "{imagecube}/small/ang20170323t202244_loc_7000-7010",
+  "{examples}/image_cube/small",
+  "ang",
+  "--surface_path {examples}/image_cube/small/configs/surface.json",
+  "--emulator_base {srtmnet}/sRTMnet_v120.h5",
+  "--n_cores {cores}",
+  "--presolve",
+  "--segmentation_size 400",
+  "--pressure_elevation",
+  "--empirical_line"
+]


### PR DESCRIPTION
Changes:
- Renamed templates `[size]-chunk` to `default`
- Added `empirical` and `analytical` line templates
- Added `emulator_base` to all templates