### PR TITLE
Patch to order of apply_oe input arguments in image cube example templates

### DIFF
--- a/image_cube/medium/templates/analytical.args.json
+++ b/image_cube/medium/templates/analytical.args.json
@@ -1,7 +1,7 @@
 [
   "{imagecube}/medium/ang20170323t202244_rdn_7k-8k",
-  "{imagecube}/medium/ang20170323t202244_obs_7k-8k",
   "{imagecube}/medium/ang20170323t202244_loc_7k-8k",
+  "{imagecube}/medium/ang20170323t202244_obs_7k-8k",
   "{examples}/image_cube/medium",
   "ang",
   "--surface_path {examples}/image_cube/medium/configs/surface.json",

--- a/image_cube/medium/templates/default.args.json
+++ b/image_cube/medium/templates/default.args.json
@@ -1,7 +1,7 @@
 [
   "{imagecube}/medium/ang20170323t202244_rdn_7k-8k",
-  "{imagecube}/medium/ang20170323t202244_obs_7k-8k",
   "{imagecube}/medium/ang20170323t202244_loc_7k-8k",
+  "{imagecube}/medium/ang20170323t202244_obs_7k-8k",
   "{examples}/image_cube/medium",
   "ang",
   "--surface_path {examples}/image_cube/medium/configs/surface.json",

--- a/image_cube/medium/templates/empirical.args.json
+++ b/image_cube/medium/templates/empirical.args.json
@@ -1,7 +1,7 @@
 [
   "{imagecube}/medium/ang20170323t202244_rdn_7k-8k",
-  "{imagecube}/medium/ang20170323t202244_obs_7k-8k",
   "{imagecube}/medium/ang20170323t202244_loc_7k-8k",
+  "{imagecube}/medium/ang20170323t202244_obs_7k-8k",
   "{examples}/image_cube/medium",
   "ang",
   "--surface_path {examples}/image_cube/medium/configs/surface.json",

--- a/image_cube/small/templates/analytical.args.json
+++ b/image_cube/small/templates/analytical.args.json
@@ -1,7 +1,7 @@
 [
   "{imagecube}/small/ang20170323t202244_rdn_7000-7010",
-  "{imagecube}/small/ang20170323t202244_obs_7000-7010",
   "{imagecube}/small/ang20170323t202244_loc_7000-7010",
+  "{imagecube}/small/ang20170323t202244_obs_7000-7010",
   "{examples}/image_cube/small",
   "ang",
   "--surface_path {examples}/image_cube/small/configs/surface.json",

--- a/image_cube/small/templates/default.args.json
+++ b/image_cube/small/templates/default.args.json
@@ -1,7 +1,7 @@
 [
   "{imagecube}/small/ang20170323t202244_rdn_7000-7010",
-  "{imagecube}/small/ang20170323t202244_obs_7000-7010",
   "{imagecube}/small/ang20170323t202244_loc_7000-7010",
+  "{imagecube}/small/ang20170323t202244_obs_7000-7010",
   "{examples}/image_cube/small",
   "ang",
   "--surface_path {examples}/image_cube/small/configs/surface.json",

--- a/image_cube/small/templates/empirical.args.json
+++ b/image_cube/small/templates/empirical.args.json
@@ -1,7 +1,7 @@
 [
   "{imagecube}/small/ang20170323t202244_rdn_7000-7010",
-  "{imagecube}/small/ang20170323t202244_obs_7000-7010",
   "{imagecube}/small/ang20170323t202244_loc_7000-7010",
+  "{imagecube}/small/ang20170323t202244_obs_7000-7010",
   "{examples}/image_cube/small",
   "ang",
   "--surface_path {examples}/image_cube/small/configs/surface.json",


### PR DESCRIPTION
The templates for the small and medium image cube examples showed the wrong order of input loc and obs files, leading to failing runs. This PR introduces the correct order following the definitions in apply_oe.