### PR TITLE
Fixed {data}/data/ redundancy

### DIFF
--- a/20250308_AV3Cal_wltest/templates/AV320250308t200738_wltest_isofit_swir_shift.json
+++ b/20250308_AV3Cal_wltest/templates/AV320250308t200738_wltest_isofit_swir_shift.json
@@ -45,7 +45,7 @@
             "radiative_transfer_engines": {
                 "vswir": {
                     "aerosol_model_file": "{data}/aerosol_model.txt",
-                    "aerosol_template_file": "{data}/data/aerosol_template.json",
+                    "aerosol_template_file": "{data}/aerosol_template.json",
                     "earth_sun_distance_file": "{data}/earth_sun_distance.txt",
                     "wavelength_file": "{examples}/20250308_AV3Cal_wltest/remote/wavelengths_highres.txt",
                     "irradiance_file": "{examples}/20151026_SantaMonica/data/prism_optimized_irr.dat",

--- a/20250308_AV3Cal_wltest/templates/AV320250308t200738_wltest_isofit_swir_spline.json
+++ b/20250308_AV3Cal_wltest/templates/AV320250308t200738_wltest_isofit_swir_spline.json
@@ -75,7 +75,7 @@
             "radiative_transfer_engines": {
                 "vswir": {
                     "aerosol_model_file": "{data}/aerosol_model.txt",
-                    "aerosol_template_file": "{data}/data/aerosol_template.json",
+                    "aerosol_template_file": "{data}/aerosol_template.json",
                     "earth_sun_distance_file": "{data}/earth_sun_distance.txt",
                     "wavelength_file": "{examples}/20250308_AV3Cal_wltest/remote/wavelengths_highres.txt",
                     "irradiance_file": "{examples}/20151026_SantaMonica/data/prism_optimized_irr.dat",


### PR DESCRIPTION
Paths don't exist due to an extra `/data/` in the string. Needed before checks on https://github.com/isofit/isofit/pull/653 can pass