### PR TITLE
LibRadTran Pasadena Example

### DIFF
--- a/20171108_Pasadena/templates/ang20171108t184227_libradtran.inp
+++ b/20171108_Pasadena/templates/ang20171108t184227_libradtran.inp
@@ -1,0 +1,22 @@
+atmosphere_file midlatitude_winter
+source solar {data}/kurudz_0.1nm.dat
+albedo {albedo}
+rte_solver disort
+pseudospherical
+umu 1.0
+phi 0.0
+phi0 180.0
+zout 2.3
+altitude 0.24
+time 2017 11 08 18 42 27
+mol_modify O3 300 DU
+latitude N 34.139247
+longitude W 118.127521
+output_user lambda uu eglo
+mol_abs_param reptran fine
+mol_modify H2O {h2o_mm} MM
+crs_model rayleigh bodhaine
+wavelength 350.0 2520.0
+aerosol_default
+aerosol_visibility {aerosol_visibility}
+quiet

--- a/20171108_Pasadena/templates/libradtran/and20171108t184227_beckmanlawn-libradtran.json
+++ b/20171108_Pasadena/templates/libradtran/and20171108t184227_beckmanlawn-libradtran.json
@@ -1,0 +1,76 @@
+{
+  "input": {
+    "measured_radiance_file": "{examples}/20171108_Pasadena/remote/ang20171108t184227_rdn_v2p11_BeckmanLawn.txt",
+    "reference_reflectance_file": "{examples}/20171108_Pasadena/insitu/BeckmanLawn.txt"
+  },
+
+  "output": {
+    "estimated_reflectance_file": "{examples}/20171108_Pasadena/output/ang20171108t184227_rfl_v2p11_BeckmanLawn-libRadTran.txt",
+    "algebraic_inverse_file": "{examples}/20171108_Pasadena/output/ang20171108t184227_alg_v2p11_BeckmanLawn-libRadTran.txt",
+    "modeled_radiance_file":  "{examples}/20171108_Pasadena/output/ang20171108t184227_mdl_v2p11_BeckmanLawn-libRadTran.txt",
+    "data_dump_file":         "{examples}/20171108_Pasadena/output/ang20171108t184227_data_v2p11_BeckmanLawn-libRadTran.mat",
+    "posterior_errors_file":  "{examples}/20171108_Pasadena/output/ang20171108t184227_post_v2p11_BeckmanLawn-libRadTran.mat",
+    "plot_directory": "{examples}/20171108_Pasadena/images/"
+  },
+
+  "forward_model":{
+
+    "instrument": {
+      "wavelength_file": "{examples}/20171108_Pasadena/remote/20170320_ang20170228_wavelength_fit.txt",
+      "parametric_noise_file": "{data}/avirisng_noise.txt",
+      "integrations": 294,
+      "unknowns": {
+        "channelized_radiometric_uncertainty_file":
+          "{data}/avirisng_systematic_error.txt",
+        "uncorrelated_radiometric_uncertainty": 0.02
+      }
+    },
+
+    "surface": {
+      "surface_category": "multicomponent_surface",
+      "surface_file": "{examples}/20171108_Pasadena/remote/ang20170228_surface_model.mat"
+    },
+
+    "radiative_transfer": {
+      "statevector": {
+        "H2OSTR": {
+          "bounds": [1.5, 2.0],
+          "scale": 0.01,
+          "prior_mean": 1.75,
+          "prior_sigma": 0.5,
+          "init": 1.75
+        },
+        "AOT550": {
+          "bounds": [0.01, 0.1],
+          "scale": 0.01,
+          "prior_mean": 0.05,
+          "prior_sigma": 0.2,
+          "init": 0.05
+        }
+      },
+      "lut_grid": {
+        "H2OSTR": [1.5, 2.0],
+        "AOT550": [0.01, 0.1]
+      },
+      "unknowns": {
+        "H2O_ABSCO": 0.01
+      },
+      "radiative_transfer_engines": {
+        "vswir": {
+          "engine_name": "libradtran",
+          "wavelength_range": [370, 2505],
+          "sim_path": "{examples}/20171108_Pasadena/lut/",
+          "lut_path": "{examples}/20171108_Pasadena/lut/ang20171108t184227_libradtran.nc",
+          "template_file": "{examples}/20171108_Pasadena/configs/ang20171108t184227_libradtran.inp",
+          "lut_names": ["H2OSTR", "AOT550"]
+        }
+      }
+    }
+  },
+
+  "implementation": {
+    "inversion": {
+      "windows": [[380.0, 1300.0], [1450, 1780.0], [1950.0, 2450.0]]
+    }
+  }
+}

--- a/20171108_Pasadena/templates/libradtran/and20171108t184227_beckmanlawn-libradtran.json
+++ b/20171108_Pasadena/templates/libradtran/and20171108t184227_beckmanlawn-libradtran.json
@@ -57,12 +57,12 @@
       },
       "radiative_transfer_engines": {
         "vswir": {
-          "engine_name": "libradtran",
+          "engine_name": "LibRadTran",
           "wavelength_range": [370, 2505],
           "sim_path": "{examples}/20171108_Pasadena/lut/",
           "lut_path": "{examples}/20171108_Pasadena/lut/ang20171108t184227_libradtran.nc",
           "template_file": "{examples}/20171108_Pasadena/configs/ang20171108t184227_libradtran.inp",
-          "lut_names": ["H2OSTR", "AOT550"]
+          "lut_names": {"H2OSTR": null, "AOT550": null}
         }
       }
     }


### PR DESCRIPTION
Ported the LibRadTran [ISOFIT v2](https://github.com/isofit/isofit/blob/dev_2x/examples/20171108_Pasadena/configs/ang20171108t184227_beckmanlawn-libradtran.json) example for Pasadena Beckmanlawn