### PR TITLE
Hatch Build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,10 @@ dependencies = [
     "mkdocs>=1.6.1",
     "mkdocs-nbconvert>=0.5",
 ]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["notebooks"]


### PR DESCRIPTION
Switched the backend build from setuptools to hatch to resolve the build error introduced by removing the setup.cfg