### PR TITLE
Install Fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["isotuts"]
+
+[tool.hatch.metadata]
+allow-direct-references = true


### PR DESCRIPTION
> ValueError: Dependency #1 of option `dev` of field `project.optional-dependencies` cannot be a direct reference unless field `tool.hatch.metadata.allow-direct-references` is set to `true`

Error on hatch when attempting to install the extra section `dev`, this fix it